### PR TITLE
ReaderSDK 1 SceneDelegate workaround

### DIFF
--- a/SquareReaderSDKTest/AppDelegate.swift
+++ b/SquareReaderSDKTest/AppDelegate.swift
@@ -27,7 +27,8 @@ extension UIApplication {
 @available(iOS 13.0, *)
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
+    var window: UIWindow?
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
 
@@ -35,24 +36,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         SQRDReaderSDK.initialize(applicationLaunchOptions: launchOptions)
 
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.backgroundColor = SampleApp.backgroundColor
+        window.rootViewController = ViewController()
+        window.makeKeyAndVisible()
+        self.window = window
+
         return true
     }
-
-    // MARK: UISceneSession Lifecycle
-
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
-        print("App Delegate configurationForConnecting:connectingSceneSession: applicationState: \(UIApplication.shared.applicationStateString)")
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
-    }
-    
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-    }
-
 
 }
 

--- a/SquareReaderSDKTest/AppDelegate.swift
+++ b/SquareReaderSDKTest/AppDelegate.swift
@@ -9,12 +9,29 @@
 import UIKit
 import SquareReaderSDK
 
+extension UIApplication {
+    var applicationStateString: String {
+        switch applicationState {
+        case .active:
+            return "Active"
+        case .background:
+            return "Background"
+        case .inactive:
+            return "Inactive"
+        @unknown default:
+            fatalError()
+        }
+    }
+}
+
 @available(iOS 13.0, *)
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+
+        print("App Delegate didFinishLaunchinWithOptions applicationState: \(UIApplication.shared.applicationStateString)")
 
         SQRDReaderSDK.initialize(applicationLaunchOptions: launchOptions)
 
@@ -26,9 +43,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
+        print("App Delegate configurationForConnecting:connectingSceneSession: applicationState: \(UIApplication.shared.applicationStateString)")
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
-
+    
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.

--- a/SquareReaderSDKTest/Info.plist
+++ b/SquareReaderSDKTest/Info.plist
@@ -27,16 +27,7 @@
 		<key>UISceneConfigurations</key>
 		<dict>
 			<key>UIWindowSceneSessionRoleApplication</key>
-			<array>
-				<dict>
-					<key>UISceneConfigurationName</key>
-					<string>Default Configuration</string>
-					<key>UISceneDelegateClassName</key>
-					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
-				</dict>
-			</array>
+			<array/>
 		</dict>
 	</dict>
 	<key>UILaunchStoryboardName</key>

--- a/SquareReaderSDKTest/SceneDelegate.swift
+++ b/SquareReaderSDKTest/SceneDelegate.swift
@@ -47,19 +47,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
-        let applicationState: String = {
-            switch UIApplication.shared.applicationState {
-            case .active:
-                return "Active"
-            case .background:
-                return "Background"
-            case .inactive:
-                return "Inactive"
-            @unknown default:
-                fatalError()
-            }
-        }()
-        
         print("sceneDelegate sceneWillEnterForeground applicationState: \(UIApplication.shared.applicationStateString)")
     }
 

--- a/SquareReaderSDKTest/SceneDelegate.swift
+++ b/SquareReaderSDKTest/SceneDelegate.swift
@@ -18,6 +18,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        print("sceneDelegate willConnectTo applicationState: \(UIApplication.shared.applicationStateString)")
+        
         guard let _ = (scene as? UIWindowScene) else { return }
     }
 
@@ -32,6 +34,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+        print("sceneDelegate didBecomeActive applicationState: \(UIApplication.shared.applicationStateString)")
     }
 
     @available(iOS 13.0, *)
@@ -44,6 +47,20 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
+        let applicationState: String = {
+            switch UIApplication.shared.applicationState {
+            case .active:
+                return "Active"
+            case .background:
+                return "Background"
+            case .inactive:
+                return "Inactive"
+            @unknown default:
+                fatalError()
+            }
+        }()
+        
+        print("sceneDelegate sceneWillEnterForeground applicationState: \(UIApplication.shared.applicationStateString)")
     }
 
     @available(iOS 13.0, *)

--- a/SquareReaderSDKTest/ViewController.swift
+++ b/SquareReaderSDKTest/ViewController.swift
@@ -22,9 +22,9 @@ class ViewController: UIViewController {
 
         // The user may be directed to the Settings app to change their permissions.
         // When they return, update the current screen.
-        NotificationCenter.default.addObserver(self, selector: #selector(updateScreen), name: UIApplication.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateScreen), name: UIApplication.didBecomeActiveNotification, object: nil)
     }
-    
+        
     @objc internal func updateScreen() {
         let permissionsGranted = PermissionsViewController.areRequiredPermissionsGranted
         let readerSDKAuthorized = SQRDReaderSDK.shared.isAuthorized


### PR DESCRIPTION
Unfortunately, Reader SDK 1 on iOS does not work well with Scenes. This is due to the fact that the SDK relies on the `UIApplication.shared.applicationState != .background` when initializing.

When a project utilizes scenes, `didFinishLaunchingWithOptions`, where `SQRDReaderSDK.initilize` should be called, the application state is `.background` instead of `.inactive`.

In order to drop scenes from the project:

1. Remove the following plist value: `Application Scene Manifest -> Scene Configuration -> Application Session Role -> Default Configuration`
1. Remove all `UISceneSessionLifeCycle` callbacks from your `AppDelegate`